### PR TITLE
Handle all passed options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,14 @@ and pass it as a query param.
 ```bash
 curl -X POST github-changelog-api.herokuapp.com/:user/:repo?token=123
 ```
+
 ## Query Params
 
-### ?token=<string>
+All [`github-changelog-generator` additional options](https://github.com/github-changelog-generator/github-changelog-generator/wiki/Advanced-change-log-generation-examples#additional-options) are supported via camel cased query params. For example:
 
-Add a GitHub personal access token for access to private repos and a higher rate limit.
-
-### ?maxIssues=<number>
-
-Limit the number of issues fetched.  Useful for avoiding rate limits and lengthy changelog generation times.
+- `--filter-by-milestone` => `?filterByMilestone=true`
+- `--header-label "# Changelog"` => `?headerLabel=%22%23%20Changelog%22`
+- `--future-release v5.0.21` => `?futureRelease=v5.0.21`
 
 ## Contribute
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "express": "^4.15.0",
     "fs-promise": "^2.0.3",
+    "lodash": "^4.17.10",
     "morgan": "^1.8.1",
     "nodemon": "^1.8.1"
   }

--- a/server/index.js
+++ b/server/index.js
@@ -28,9 +28,9 @@ app
 
   .post('/:user/:repo', (req, res) => {
     const { user, repo } = req.params
-    const { token, maxIssues } = req.query
+    const options = req.query
 
-    generateChangelog(user, repo, { token, maxIssues })
+    generateChangelog(user, repo, options)
 
     res.status(200).send([
       `Started a job for ${user}/${repo}. `,


### PR DESCRIPTION
Hey there. Thanks for this repo, it's really useful 💯 

This patch should allow the handling of extra options, beyond just `token` and `maxIssues`. This was something that was brought up in #8 I believe, so using that as an example you could pass `githubSite` as a query param, and it would be passed through to `github-changelog-api` as `--github-site`.

Not quite sure how to test this thoroughly, but have had a poke about and it _seems_ ok 😅 

(PS: If you think trying to handle every option could open a can of worms, I'm happy to amend this patch to only add in handling of the extra couple of params/options I'm interested in).