### PR TITLE
Use correct changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,118 +1,26 @@
 # Change Log
 
-## [Unreleased](https://github.com/dev-coop/anny/tree/HEAD)
+## [Unreleased](https://github.com/levithomason/github-changelog-api/tree/HEAD)
 
-[Full Changelog](https://github.com/dev-coop/anny/compare/v0.2.0...HEAD)
-
-**Closed issues:**
-
-- Create Trainer class [\#91](https://github.com/dev-coop/anny/issues/91)
-- Network.train\(\) should not log on succes/fail [\#45](https://github.com/dev-coop/anny/issues/45)
-
-**Merged pull requests:**
-
-- Add Trainer class [\#93](https://github.com/dev-coop/anny/pull/93) ([levithomason](https://github.com/levithomason))
-- Cleanup Neuron train method [\#92](https://github.com/dev-coop/anny/pull/92) ([levithomason](https://github.com/levithomason))
-
-## [v0.2.0](https://github.com/dev-coop/anny/tree/v0.2.0) (2015-12-21)
-[Full Changelog](https://github.com/dev-coop/anny/compare/v0.1.2...v0.2.0)
-
-**Closed issues:**
-
-- Remove mathjs dependency [\#82](https://github.com/dev-coop/anny/issues/82)
-- Validation before training  [\#77](https://github.com/dev-coop/anny/issues/77)
-- Implement batch training [\#28](https://github.com/dev-coop/anny/issues/28)
-
-**Merged pull requests:**
-
-- Remove Network.train\(\) console.logs in favor of callbacks [\#90](https://github.com/dev-coop/anny/pull/90) ([levithomason](https://github.com/levithomason))
-- Remove mathjs dependency [\#87](https://github.com/dev-coop/anny/pull/87) ([levithomason](https://github.com/levithomason))
-- Increase coverage [\#86](https://github.com/dev-coop/anny/pull/86) ([levithomason](https://github.com/levithomason))
-- Integration [\#85](https://github.com/dev-coop/anny/pull/85) ([levithomason](https://github.com/levithomason))
-- Validate training data before training [\#83](https://github.com/dev-coop/anny/pull/83) ([levithomason](https://github.com/levithomason))
-
-## [v0.1.2](https://github.com/dev-coop/anny/tree/v0.1.2) (2015-11-14)
-[Full Changelog](https://github.com/dev-coop/anny/compare/v0.1.1...v0.1.2)
-
-**Merged pull requests:**
-
-- Integration [\#80](https://github.com/dev-coop/anny/pull/80) ([levithomason](https://github.com/levithomason))
-- Do not squash input values [\#79](https://github.com/dev-coop/anny/pull/79) ([levithomason](https://github.com/levithomason))
-- Update README.md [\#76](https://github.com/dev-coop/anny/pull/76) ([levithomason](https://github.com/levithomason))
-- update readme [\#75](https://github.com/dev-coop/anny/pull/75) ([levithomason](https://github.com/levithomason))
-
-## [v0.1.1](https://github.com/dev-coop/anny/tree/v0.1.1) (2015-10-31)
-[Full Changelog](https://github.com/dev-coop/anny/compare/v0.1.0...v0.1.1)
-
-## [v0.1.0](https://github.com/dev-coop/anny/tree/v0.1.0) (2015-10-31)
 **Implemented enhancements:**
 
-- Parallelize training [\#23](https://github.com/dev-coop/anny/issues/23)
-- API Docs [\#15](https://github.com/dev-coop/anny/issues/15)
+- Support Github Enterprise [\#8](https://github.com/levithomason/github-changelog-api/issues/8)
 
 **Closed issues:**
 
-- Better way to add bias neuron [\#58](https://github.com/dev-coop/anny/issues/58)
-- Add changelog [\#44](https://github.com/dev-coop/anny/issues/44)
-- Input neurons should not use activationFn [\#31](https://github.com/dev-coop/anny/issues/31)
-- No anonymous functions [\#19](https://github.com/dev-coop/anny/issues/19)
+- Question about read VS write auth token [\#3](https://github.com/levithomason/github-changelog-api/issues/3)
 
 **Merged pull requests:**
 
-- Integration [\#74](https://github.com/dev-coop/anny/pull/74) ([levithomason](https://github.com/levithomason))
-- move deploy to separate script [\#73](https://github.com/dev-coop/anny/pull/73) ([levithomason](https://github.com/levithomason))
-- fix multiline deploy script [\#72](https://github.com/dev-coop/anny/pull/72) ([levithomason](https://github.com/levithomason))
-- fix circle deploy script [\#71](https://github.com/dev-coop/anny/pull/71) ([levithomason](https://github.com/levithomason))
-- remove ruby-version file [\#70](https://github.com/dev-coop/anny/pull/70) ([levithomason](https://github.com/levithomason))
-- Integration [\#69](https://github.com/dev-coop/anny/pull/69) ([levithomason](https://github.com/levithomason))
-- Update linter [\#68](https://github.com/dev-coop/anny/pull/68) ([levithomason](https://github.com/levithomason))
-- Integration [\#67](https://github.com/dev-coop/anny/pull/67) ([levithomason](https://github.com/levithomason))
-- Example data [\#66](https://github.com/dev-coop/anny/pull/66) ([levithomason](https://github.com/levithomason))
-- Integration [\#65](https://github.com/dev-coop/anny/pull/65) ([levithomason](https://github.com/levithomason))
-- Neuron config [\#64](https://github.com/dev-coop/anny/pull/64) ([levithomason](https://github.com/levithomason))
-- update doc site styles, add clean-wercker command [\#63](https://github.com/dev-coop/anny/pull/63) ([levithomason](https://github.com/levithomason))
-- Integration [\#61](https://github.com/dev-coop/anny/pull/61) ([levithomason](https://github.com/levithomason))
-- add github token to changelog generator step [\#60](https://github.com/dev-coop/anny/pull/60) ([levithomason](https://github.com/levithomason))
-- removed cached ignored [\#57](https://github.com/dev-coop/anny/pull/57) ([levithomason](https://github.com/levithomason))
-- update doc site styles, add clean-wercker command [\#55](https://github.com/dev-coop/anny/pull/55) ([levithomason](https://github.com/levithomason))
-- add config for codeclimate platform [\#54](https://github.com/dev-coop/anny/pull/54) ([levithomason](https://github.com/levithomason))
-- always gem install changelog [\#53](https://github.com/dev-coop/anny/pull/53) ([levithomason](https://github.com/levithomason))
-- upgrade git in deploy [\#52](https://github.com/dev-coop/anny/pull/52) ([levithomason](https://github.com/levithomason))
-- Add bower echo more version info during deploy [\#51](https://github.com/dev-coop/anny/pull/51) ([levithomason](https://github.com/levithomason))
-- Integration [\#50](https://github.com/dev-coop/anny/pull/50) ([levithomason](https://github.com/levithomason))
-- Add changelog [\#49](https://github.com/dev-coop/anny/pull/49) ([levithomason](https://github.com/levithomason))
-- Integration [\#48](https://github.com/dev-coop/anny/pull/48) ([levithomason](https://github.com/levithomason))
-- Move to ES6 [\#47](https://github.com/dev-coop/anny/pull/47) ([levithomason](https://github.com/levithomason))
-- Integration [\#43](https://github.com/dev-coop/anny/pull/43) ([levithomason](https://github.com/levithomason))
-- add Neuron.activate\(\) tests [\#41](https://github.com/dev-coop/anny/pull/41) ([levithomason](https://github.com/levithomason))
-- Integration [\#40](https://github.com/dev-coop/anny/pull/40) ([levithomason](https://github.com/levithomason))
-- add hacking tutorial [\#39](https://github.com/dev-coop/anny/pull/39) ([levithomason](https://github.com/levithomason))
-- Fix app docs link [\#38](https://github.com/dev-coop/anny/pull/38) ([levithomason](https://github.com/levithomason))
-- remove ignored from git cache [\#37](https://github.com/dev-coop/anny/pull/37) ([levithomason](https://github.com/levithomason))
-- Feature/update readme [\#36](https://github.com/dev-coop/anny/pull/36) ([levithomason](https://github.com/levithomason))
-- Add docs link in app and /docs redirect to latest dist [\#35](https://github.com/dev-coop/anny/pull/35) ([levithomason](https://github.com/levithomason))
-- Fork me ribbon [\#34](https://github.com/dev-coop/anny/pull/34) ([levithomason](https://github.com/levithomason))
-- Check for dirty repo before deploy commit [\#33](https://github.com/dev-coop/anny/pull/33) ([levithomason](https://github.com/levithomason))
-- Setup wercker [\#32](https://github.com/dev-coop/anny/pull/32) ([levithomason](https://github.com/levithomason))
-- Constructor options [\#30](https://github.com/dev-coop/anny/pull/30) ([levithomason](https://github.com/levithomason))
-- Better default logger, shorter frequency [\#26](https://github.com/dev-coop/anny/pull/26) ([levithomason](https://github.com/levithomason))
-- Add API Docs [\#24](https://github.com/dev-coop/anny/pull/24) ([levithomason](https://github.com/levithomason))
-- Normalize min max [\#22](https://github.com/dev-coop/anny/pull/22) ([levithomason](https://github.com/levithomason))
-- add local lato font [\#20](https://github.com/dev-coop/anny/pull/20) ([levithomason](https://github.com/levithomason))
-- adds mathjs, fix tests [\#18](https://github.com/dev-coop/anny/pull/18) ([levithomason](https://github.com/levithomason))
-- Add default training logger [\#17](https://github.com/dev-coop/anny/pull/17) ([levithomason](https://github.com/levithomason))
-- Update demo [\#12](https://github.com/dev-coop/anny/pull/12) ([levithomason](https://github.com/levithomason))
-- Update all weights [\#11](https://github.com/dev-coop/anny/pull/11) ([levithomason](https://github.com/levithomason))
-- util tests [\#10](https://github.com/dev-coop/anny/pull/10) ([levithomason](https://github.com/levithomason))
-- add activation tests [\#9](https://github.com/dev-coop/anny/pull/9) ([levithomason](https://github.com/levithomason))
-- Update demo [\#8](https://github.com/dev-coop/anny/pull/8) ([levithomason](https://github.com/levithomason))
-- Cross Entropy [\#7](https://github.com/dev-coop/anny/pull/7) ([levithomason](https://github.com/levithomason))
-- Shields.io [\#6](https://github.com/dev-coop/anny/pull/6) ([levithomason](https://github.com/levithomason))
-- App lint and codeclimate [\#5](https://github.com/dev-coop/anny/pull/5) ([levithomason](https://github.com/levithomason))
-- Train [\#4](https://github.com/dev-coop/anny/pull/4) ([levithomason](https://github.com/levithomason))
-- Coverage [\#3](https://github.com/dev-coop/anny/pull/3) ([levithomason](https://github.com/levithomason))
-- Lint [\#2](https://github.com/dev-coop/anny/pull/2) ([levithomason](https://github.com/levithomason))
-- More tests [\#1](https://github.com/dev-coop/anny/pull/1) ([levithomason](https://github.com/levithomason))
+- fs-promise@2.0.3 untested ⚠️ [\#12](https://github.com/levithomason/github-changelog-api/pull/12) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- fs-promise@2.0.2 untested ⚠️ [\#11](https://github.com/levithomason/github-changelog-api/pull/11) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- fs-promise@2.0.1 untested ⚠️ [\#10](https://github.com/levithomason/github-changelog-api/pull/10) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- express@4.15.0 untested ⚠️ [\#9](https://github.com/levithomason/github-changelog-api/pull/9) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- Update fs-promise to version 2.0.0 🚀 [\#7](https://github.com/levithomason/github-changelog-api/pull/7) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- morgan@1.8.1 untested ⚠️ [\#6](https://github.com/levithomason/github-changelog-api/pull/6) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- express@4.14.1 untested ⚠️ [\#4](https://github.com/levithomason/github-changelog-api/pull/4) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- Update fs-promise to version 1.0.0 🚀 [\#2](https://github.com/levithomason/github-changelog-api/pull/2) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- Support private repos [\#1](https://github.com/levithomason/github-changelog-api/pull/1) ([levithomason](https://github.com/levithomason))
 
 
 


### PR DESCRIPTION
Noticed that the `CHANGELOG.md` for this repo was actually generated from the `anny` repo, so updated it for this repo using:

```
$ github_changelog_generator -u levithomason -p github-changelog-api
```

Not sure if you needed any other options passed, but figured it was a reasonable start?